### PR TITLE
Update controller test for keys in response

### DIFF
--- a/test/controllers/pets_controller_test.rb
+++ b/test/controllers/pets_controller_test.rb
@@ -32,9 +32,14 @@ class PetsControllerTest < ActionController::TestCase
   end
 
   test "each pet object contains the relevant keys" do
-    keys = %w( age human id name )
+    keys = %w( age human id name ).to_set
     get :index
-    body = JSON.parse(response.body)
-    assert_equal keys, body.map(&:keys).flatten.uniq.sort
+    pets = JSON.parse(response.body)
+    pets.each.with_index do |pet, i|
+      assert_equal keys, pet.keys.to_set, "Pet ##{i} did not have exact set of keys: #{pet}"
+      pet.keys.each do |key|
+        assert_not_nil pet[key], "Pet ##{i} had a nil value for #{key}"
+      end
+    end
   end
 end


### PR DESCRIPTION
This is a somewhat more aggressive test than before, on two counts. The
original test is extended to ensure that every pet object in the
response array has exactly the set of keys we want.

There is another test added as well, which asserts that every key in
each object has a non-nil value. This is certainly not appropriate for
every scenario, so if we want to not include it in this example project
I'll pull it out.